### PR TITLE
travis: PHP 5.6 and 7.0 nightly added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: php
 
 php:
+  - 7.0
+  - 5.6
   - 5.5
   - 5.4
+
+matrix:
+  allow_failures:
+    - php: 7.0
 
 before_install:
   - pecl install pthreads-1.0.1


### PR DESCRIPTION
See http://docs.travis-ci.com/user/languages/php/#PHP-7

Composer allows them both (with PHP >= 5.4), so they should be tested as well.