### PR TITLE
fixed logo link on welcome template

### DIFF
--- a/resources/templates/www/welcome.phtml
+++ b/resources/templates/www/welcome.phtml
@@ -69,7 +69,7 @@ Setup::prepareContext();
         <div class="cover-container">
             <div class="masthead"><br/></div>
             <div class="inner cover">
-                <img class="appserver-logo" src="http://cdn.appserver.io/welcome-page/logo_<?php echo str_replace(" ", "-", strtolower(Setup::getValue(SetupKeys::RELEASE_NAME))) . '_' . Setup::getLinuxDistro() . '_' . Setup::getValue(SetupKeys::OS_ARCHITECTURE) ?>.png">
+                <img class="appserver-logo" src="http://cdn.appserver.io/welcome-page/logo_<?php echo Setup::getValue(SetupKeys::OS_IDENTIFIER); ?>.png">
                 <h1 class="cover-heading">Congratulations!</h1>
                 <p>
                 <h4><b>appserver.io <i><?php echo Setup::getValue(SetupKeys::RELEASE_NAME) ?></i></b> is up and running...</h4>


### PR DESCRIPTION
There was no logo after install "appserver/1.1.0-100 (darwin) PHP/5.6.15" on mac os x

`GET http://cdn.appserver.io/welcome-page/logo_iron-knight__x86_64.png 404 (Not Found)`