### PR TITLE
Making PHP the main language of the repo again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore internal/* files
+internal/* linguist-documentation


### PR DESCRIPTION
A simple linguist override using gitattributes to ignore the JS files from the swagger-ui in the language repo bar.