### PR TITLE
Added support for salting

### DIFF
--- a/src/AppserverIo/Appserver/ServletEngine/Security/Auth/Spi/DatabasePDOLoginModule.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Auth/Spi/DatabasePDOLoginModule.php
@@ -162,7 +162,6 @@ class DatabasePDOLoginModule extends UsernamePasswordLoginModule
      * Returns the salt for the user from the sharedMap data.
      *
      * @return \AppserverIo\Lang\String The user's salt
-     * @throws \AppserverIo\Psr\Security\Auth\Login\LoginException Is thrown if password can't be loaded
      */
     protected function getUsersSalt()
     {
@@ -193,11 +192,11 @@ class DatabasePDOLoginModule extends UsernamePasswordLoginModule
             }
         }
 
-        // query whether or not we've a password found or not
+        // query whether or not we've found a salt or not
         if ($row = $statement->fetch(\PDO::FETCH_NUM)) {
             return new String($row[0]);
         } else {
-            throw new LoginException('No matching username found in principals');
+            return null;
         }
     }
 }

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Auth/Spi/UsernamePasswordLoginModule.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Auth/Spi/UsernamePasswordLoginModule.php
@@ -146,6 +146,14 @@ abstract class UsernamePasswordLoginModule extends AbstractLoginModule
     abstract protected function getUsersPassword();
 
     /**
+     * Returns the salt for the user from the sharedMap data.
+     *
+     * @return \AppserverIo\Lang\String The user's salt
+     * @throws \AppserverIo\Psr\Security\Auth\Login\LoginException Is thrown if salt can't be loaded
+     */
+    abstract protected function getUsersSalt();
+
+    /**
      * Perform the authentication of username and password.
      *
      * @return boolean TRUE when login has been successfull, else FALSE

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Auth/Spi/UsernamePasswordLoginModule.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Auth/Spi/UsernamePasswordLoginModule.php
@@ -266,6 +266,9 @@ abstract class UsernamePasswordLoginModule extends AbstractLoginModule
         // initialize the callback
         $callback = null;
 
+        //get users salt
+        $hashSalt = $this->getUsersSalt();
+
         // query whether or not we've a callback configured
         if ($this->params->exists(ParamKeys::DIGEST_CALLBACK)) {
             try {
@@ -278,14 +281,13 @@ abstract class UsernamePasswordLoginModule extends AbstractLoginModule
                 $tmp->add(SharedStateKeys::LOGIN_NAME, $name);
                 $tmp->add(SharedStateKeys::LOGIN_PASSWORD, $password);
                 $callback->init($tmp);
-
             } catch (\Exception $e) {
                 throw new SecurityException("Failed to load DigestCallback");
             }
         }
 
         // hash and return the password
-        return Util::createPasswordHash($this->hashAlgorithm, $this->hashEncoding, $this->hashCharset, $name, $password, $callback);
+        return Util::createPasswordHash($this->hashAlgorithm, $this->hashEncoding, $this->hashCharset, $name, $password, $callback, $hashSalt);
     }
 
     /**
@@ -315,6 +317,10 @@ abstract class UsernamePasswordLoginModule extends AbstractLoginModule
             $valid = $inputPassword->equalsIgnoreCase($expectedPassword);
         } else {
             $valid = $inputPassword->equals($expectedPassword);
+        }
+
+        if ($this->hashAlgorithm == "PASSWORD_BCRYPT" || $this->hashAlgorithm == "PASSWORD_DEFAULT") {
+            $valid = password_verify($inputPassword, $expectedPassword);
         }
 
         // return the flag

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Utils/HashKeys.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Utils/HashKeys.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AppserverIo\Appserver\ServletEngine\Security\Utils;
+
+/**
+ * @author    Alexandros Weigl <a.weigl@techdivision.com>
+ * @copyright 2016 TechDivision GmbH <info@appserver.io>
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link      https://github.com/appserver-io/appserver
+ */
+class HashKeys
+{
+    /**
+     * They key for the "md5" hash algorithm
+     *
+     * @var string
+     */
+    const MD5 = 'md5';
+
+    /**
+     * They key for the "sha1" hash algorithm
+     *
+     * @var string
+     */
+    const SHA1 = 'sha1';
+
+    /**
+     * They key for the "sha256" hash algorithm
+     *
+     * @var string
+     */
+    const SHA256 = 'sha256';
+
+    /**
+     * They key for the "sha512" hash algorithm
+     *
+     * @var string
+     */
+    const SHA512 = 'sha512';
+}

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Utils/ParamKeys.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Utils/ParamKeys.php
@@ -54,6 +54,13 @@ class ParamKeys
     const ROLES_QUERY = 'rolesQuery';
 
     /**
+     * The key for the "saltQuery" parameter.
+     *
+     * @var string
+     */
+    const SALT_QUERY = 'saltQuery';
+
+    /**
      * The key for the "passwordStacking" parameter.
      *
      * @var string

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Utils/ParamKeys.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Utils/ParamKeys.php
@@ -89,6 +89,13 @@ class ParamKeys
     const HASH_CHARSET = 'hashCharset';
 
     /**
+     * the key for the "salt" parameter.
+     *
+     * @var string
+     */
+    const HASH_SALT = 'hashSalt';
+
+    /**
      * The key for the "ignorePasswordCase" parameter.
      *
      * @var string

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Utils/Util.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Utils/Util.php
@@ -60,23 +60,40 @@ class Util
     /**
      * Creates and returns a hashed version of the passed password.
      *
+     *
      * @param string                   $hashAlgorithm The hash algorithm to use
      * @param string                   $hashEncoding  The hash encoding to use
      * @param string                   $hashCharset   The hash charset to use
      * @param \AppserverIo\Lang\String $name          The login name
      * @param \AppserverIo\Lang\String $password      The password credential
      * @param mixed                    $callback      The callback providing some additional hashing functionality
+     * @param string                   $hashSalt      The hash salt to use
      *
      * @return \AppserverIo\Lang\String The hashed password
      */
-    public static function createPasswordHash($hashAlgorithm, $hashEncoding, $hashCharset, String $name, String $password, $callback)
+    public static function createPasswordHash($hashAlgorithm, $hashEncoding, $hashCharset, String $name, String $password, $callback, $hashSalt = null)
     {
         $newPassword = clone $password;
-        return $newPassword->md5();
+        switch ($hashAlgorithm) {
+            case HashKeys::MD5:
+                return $newPassword->md5($hashSalt);
+            case HashKeys::SHA1:
+                return $newPassword->sha1($hashSalt);
+            case HashKeys::SHA256:
+                return $newPassword->sha256($hashSalt);
+            case HashKeys::SHA512:
+                return $newPassword->sha512($hashSalt);
+            case PASSWORD_BCRYPT:
+                return $newPassword;
+            case PASSWORD_DEFAULT:
+                return $newPassword;
+            case 'default':
+                return $newPassword;
+        }
     }
 
     /**
-     * Execute the rolesQuery against the dsJndiName to obtain the roles for the authenticated user.
+     * Execute the rolesQuery against the UserName to obtain the roles for the authenticated user.
      *
      * @param \AppserverIo\Lang\String                  $username   The username to load the roles for
      * @param \AppserverIo\Lang\String                  $lookupName The lookup name for the datasource
@@ -156,7 +173,6 @@ class Util
 
             // load one group after another
             } while ($row = $statement->fetch(\PDO::FETCH_OBJ));
-
         } catch (NamingException $ne) {
             throw new LoginException($ne->__toString());
         } catch (\PDOException $pdoe) {

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Utils/UtilTest.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Utils/UtilTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace AppserverIo\Appserver\ServletEngine\Security\Utils;
+
+use AppserverIo\Appserver\ServletEngine\Security\Utils\Util;
+use AppserverIo\Lang\String;
+
+/**
+ * Unit test class for Util
+ *
+ * @author    Alexandros Weigl <a.weigl@techdivision.com>
+ * @copyright 2016 TechDivision GmbH <info@appserver.io>
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link      https://github.com/appserver-io/appserver
+ */
+class UtilTest extends \PHPUnit_Framework_TestCase
+{
+    protected $password;
+    protected $name;
+    protected $salt;
+    protected $hashAlgorithm;
+    protected $hashEncoding;
+    protected $hashCharset;
+    protected $callback;
+
+    /**
+     * Setup the test data
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->name = new String("test");
+        $this->password = new String("test");
+    }
+
+    /**
+     * Test if createPasswordHash hashes md5 correctly without a given salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedMd5WithoutSalt()
+    {
+        $this->hashAlgorithm = HashKeys::MD5;
+        $expectedPassword = md5($this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback
+        );
+        $this->assertEquals($expectedPassword, $password);
+    }
+
+    /**
+     * Test if createPasswordHash hashes md5 correctly with a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedMd5WithSalt()
+    {
+        $this->hashAlgorithm = HashKeys::MD5;
+        $this->salt = '1234';
+        $expectedPassword = md5($this->salt . $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback,
+            $this->salt
+        );
+
+        $this->assertEquals($expectedPassword, $password->stringValue());
+    }
+
+    /**
+     * Test if createPasswordHash hashes SHA1 correctly without a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedSha1WithoutSalt()
+    {
+        $this->hashAlgorithm = HashKeys::SHA1;
+        $expectedPassword = hash(HashKeys::SHA1, $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback
+        );
+
+        $this->assertEquals($expectedPassword, $password);
+    }
+
+    /**
+     * Test if createPasswordHash hashes SHA1 correctly with a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedSha1WithSalt()
+    {
+        $this->hashAlgorithm = HashKeys::SHA1;
+        $this->salt = '1234';
+        $expectedPassword = hash(HashKeys::SHA1, $this->salt . $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback,
+            $this->salt
+        );
+
+        $this->assertEquals($expectedPassword, $password->stringValue());
+    }
+
+    /**
+     * Test if createPasswordHash hashes SHA256 correclty without a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedSha256WithoutSalt()
+    {
+        $this->hashAlgorithm = HashKeys::SHA256;
+        $expectedPassword = hash(HashKeys::SHA256, $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback
+        );
+
+        $this->assertEquals($expectedPassword, $password);
+    }
+
+    /**
+     * Test if createPasswordHash hashes SHA256 correctly with a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedSha256WithSalt()
+    {
+        $this->hashAlgorithm = HashKeys::SHA256;
+        $this->salt = '1234';
+        $expectedPassword = hash(HashKeys::SHA256, $this->salt . $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback,
+            $this->salt
+        );
+
+        $this->assertEquals($expectedPassword, $password->stringValue());
+    }
+
+    /**
+     * Test if createPasswordHash hashes SHA512 correclty without a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedSha512WithoutSalt()
+    {
+        $this->hashAlgorithm = HashKeys::SHA512;
+        $expectedPassword = hash(HashKeys::SHA512, $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback
+        );
+
+        $this->assertEquals($expectedPassword, $password);
+    }
+
+    /**
+     * Test if createPasswordHash hashes SHA512 correctly with a salt
+     *
+     * @return void
+     */
+    public function testCreatePasswordHashedSha512WithSalt()
+    {
+        $this->hashAlgorithm = HashKeys::SHA512;
+        $this->salt = '1234';
+        $expectedPassword = hash(HashKeys::SHA512, $this->salt . $this->password);
+        $password = Util::createPasswordHash(
+            $this->hashAlgorithm,
+            $this->hashEncoding,
+            $this->hashCharset,
+            $this->name,
+            $this->password,
+            $this->callback,
+            $this->salt
+        );
+
+        $this->assertEquals($expectedPassword, $password->stringValue());
+    }
+}


### PR DESCRIPTION
I've added support for hash salting and support for more hashing algorithms.

There's a new parameter called saltQuery which is defined in context.xml and expects
a DQL Query string to get the salt from a specified table.

The hashAlgorithm in context.xml is now being respected and can be given the following values:

* md5
* sha1
* sha256
* sha512 
* PASSWORD_BCRYPT
* PASSWORD_DEFAULT

if none of the above is given the password hashing mechanism just returns the password with no hashing.


