### PR TITLE
get the right pthreads version for php7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ matrix:
     - php: 7.0
 
 before_install:
-  - pecl install pthreads-2.0.10
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.0" ]]; then pecl install pthreads-2.0.10; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "7.0" ]] || [[ "$TRAVIS_PHP_VERSION" > "7.0" ]]; then pecl install pthreads-3.1.6; fi
   - pecl install xdebug
   - phpenv rehash
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
the build will still fail on php7
[exec]   Problem 1
[exec]     - Installation request for crunch/fastcgi 2.x-dev -> satisfiable by crunch/fastcgi[2.x-dev].
[exec]     - crunch/fastcgi 2.x-dev requires php ~5.4 -> your PHP version (7.0.13) does not satisfy that requirement.
