### PR TITLE
Load only project datasources

### DIFF
--- a/src/AppserverIo/Appserver/Core/GenericDeployment.php
+++ b/src/AppserverIo/Appserver/Core/GenericDeployment.php
@@ -63,7 +63,7 @@ class GenericDeployment extends AbstractDeployment
                 $datasourceFiles = array_merge(
                     $datasourceFiles,
                     $this->prepareDatasourceFiles(
-                        $this->getDeploymentService()->globDir(AppEnvironmentHelper::getEnvironmentAwareGlobPattern($webappPath, 'META-INF/*-ds'))
+                        $this->getDeploymentService()->globDir(AppEnvironmentHelper::getEnvironmentAwareGlobPattern($webappPath, 'META-INF' . DIRECTORY_SEPARATOR . '*-ds'))
                     )
                 );
             }

--- a/src/AppserverIo/Appserver/Core/GenericDeployment.php
+++ b/src/AppserverIo/Appserver/Core/GenericDeployment.php
@@ -63,7 +63,7 @@ class GenericDeployment extends AbstractDeployment
                 $datasourceFiles = array_merge(
                     $datasourceFiles,
                     $this->prepareDatasourceFiles(
-                        $this->getDeploymentService()->globDir(AppEnvironmentHelper::getEnvironmentAwareGlobPattern($webappPath, '*-ds'))
+                        $this->getDeploymentService()->globDir(AppEnvironmentHelper::getEnvironmentAwareGlobPattern($webappPath, 'META-INF/*-ds'))
                     )
                 );
             }


### PR DESCRIPTION
When loading the datasources for the applications, the glob function was recursively checking all the directories at the root of each application, and loading every datasource it was able to find.

With this commit the glob is limited to the META-INF directory.