### PR TITLE
Remove LoginContext from GenericPrincipal

### DIFF
--- a/src/AppserverIo/Appserver/Core/ApplicationServer.php
+++ b/src/AppserverIo/Appserver/Core/ApplicationServer.php
@@ -210,8 +210,6 @@ class ApplicationServer extends \Thread implements ApplicationServerInterface
      * @param array $loggers The logger instances to set
      *
      * @return void
-     *
-     * @return void
      */
     public function setLoggers(array $loggers)
     {
@@ -435,7 +433,6 @@ class ApplicationServer extends \Thread implements ApplicationServerInterface
      * The thread's run() method that runs asynchronously.
      *
      * @return void
-     * @return void
      * @link http://www.php.net/manual/en/thread.run.php
      */
     public function run()
@@ -619,8 +616,6 @@ class ApplicationServer extends \Thread implements ApplicationServerInterface
      * @param string  $name     The name of the requested service
      *
      * @return mixed The service instance
-     *
-     * @return mixed The service instance
      */
     public function getService($runlevel, $name)
     {
@@ -687,8 +682,6 @@ class ApplicationServer extends \Thread implements ApplicationServerInterface
 
     /**
      * Loads the bootstrap configuration from the XML file.
-     *
-     * @param string $bootstrapConfigurationFilename The boostrap configuration file
      *
      * @param string $bootstrapConfigurationFilename The boostrap configuration file
      *

--- a/src/AppserverIo/Appserver/ServletEngine/Security/GenericPrincipal.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/GenericPrincipal.php
@@ -68,10 +68,10 @@ class GenericPrincipal extends SimplePrincipal
     /**
      * Initializes the principal with the data from the passed objects.
      *
-     * @param \AppserverIo\Lang\String                                   $username      The principal's username
-     * @param \AppserverIo\Lang\String                                   $password      The principal's password
-     * @param \AppserverIo\Collection\ArrayList                          $roles         The principal's roles
-     * @param \AppserverIo\Psr\Security\PrincipalInterface               $userPrincipal The user principal instance that will be returned from the request
+     * @param \AppserverIo\Lang\String                     $username      The principal's username
+     * @param \AppserverIo\Lang\String                     $password      The principal's password
+     * @param \AppserverIo\Collection\ArrayList            $roles         The principal's roles
+     * @param \AppserverIo\Psr\Security\PrincipalInterface $userPrincipal The user principal instance that will be returned from the request
      */
     public function __construct(
         String $username = null,

--- a/src/AppserverIo/Appserver/ServletEngine/Security/GenericPrincipal.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/GenericPrincipal.php
@@ -23,7 +23,6 @@ namespace AppserverIo\Appserver\ServletEngine\Security;
 use AppserverIo\Lang\String;
 use AppserverIo\Collections\ArrayList;
 use AppserverIo\Psr\Security\PrincipalInterface;
-use AppserverIo\Psr\Security\Auth\Login\LoginContextInterface;
 
 /**
  * A simple String based implementation of Principal. Typically a SimplePrincipal is
@@ -67,34 +66,24 @@ class GenericPrincipal extends SimplePrincipal
     protected $userPrincipal;
 
     /**
-     * The actual login context instance.
-     *
-     * @var \AppserverIo\Psr\Security\Auth\Login\LoginContextInterface
-     */
-    protected $loginContext;
-
-    /**
      * Initializes the principal with the data from the passed objects.
      *
      * @param \AppserverIo\Lang\String                                   $username      The principal's username
      * @param \AppserverIo\Lang\String                                   $password      The principal's password
      * @param \AppserverIo\Collection\ArrayList                          $roles         The principal's roles
      * @param \AppserverIo\Psr\Security\PrincipalInterface               $userPrincipal The user principal instance that will be returned from the request
-     * @param \AppserverIo\Psr\Security\Auth\Login\LoginContextInterface $loginContext  The actual login context instance
      */
     public function __construct(
         String $username = null,
         String $password = null,
         ArrayList $roles = null,
-        PrincipalInterface $userPrincipal = null,
-        LoginContextInterface $loginContext = null
+        PrincipalInterface $userPrincipal = null
     ) {
 
         // set the passed instances
         $this->username = $username;
         $this->password = $password;
         $this->userPrincipal = $userPrincipal;
-        $this->loginContext = $loginContext;
 
         // set the roles or initialize an empty ArrayList
         if ($roles == null) {
@@ -142,15 +131,5 @@ class GenericPrincipal extends SimplePrincipal
     public function getUserPrincipal()
     {
         return $this->userPrincipal;
-    }
-
-    /**
-     * Return's the actual login context instance.
-     *
-     * @return the \AppserverIo\Psr\Security\Auth\Login\LoginContextInterface The login context instance
-     */
-    public function getLoginContext()
-    {
-        return $this->loginContext;
     }
 }

--- a/src/AppserverIo/Appserver/ServletEngine/Security/Realm.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Security/Realm.php
@@ -237,6 +237,6 @@ class Realm implements RealmInterface
         }
 
         // return the resulting Principal for our authenticated user
-        return new GenericPrincipal($username, null, $roles, $userPrincipal, $loginContext);
+        return new GenericPrincipal($username, null, $roles, $userPrincipal);
     }
 }


### PR DESCRIPTION
This PR removes the LoginContext instance from the GenericPrincipal, which is being stored in the current session. Not only because the LoginContext contains sensitive information like the password used to authenticate the user but also because it is neither needed by the ServletEngine nor by the application.