### PR TITLE
Support optional encryption parameter

### DIFF
--- a/src/AppserverIo/Appserver/Doctrine/Utils/ConnectionUtil.php
+++ b/src/AppserverIo/Appserver/Doctrine/Utils/ConnectionUtil.php
@@ -134,6 +134,11 @@ class ConnectionUtil
         if ($databasePortNode = $databaseNode->getDatabasePort()) {
             $connectionParameters['port'] = $databasePortNode->getNodeValue()->__toString();
         }
+        
+	// adds the optional encryption option
+        if ($encryptionNode = $databaseNode->getEncryption()) {
+            $connectionParameters['encryption'] = $encryptionNode->getNodeValue()->__toString();
+        }
 
         // add charset, if specified
         if ($charsetNode = $databaseNode->getCharset()) {

--- a/src/AppserverIo/Appserver/Ldap/EntityManagerFactory.php
+++ b/src/AppserverIo/Appserver/Ldap/EntityManagerFactory.php
@@ -143,7 +143,8 @@ class EntityManagerFactory
             $ldapClient = new LdapClient(
                 Ldap::create($connectionParameters['driver'], [
                     'host' => $connectionParameters['host'],
-                    'port' => $connectionParameters['port']
+                    'port' => $connectionParameters['port'],
+                    'encryption' => $connectionParameters['encryption']
                 ])
             );
 


### PR DESCRIPTION
Enables use of the optional `<encryption>ssl</encryption>` LDAP DataStore configuration parameter.

Requires Pull Requests https://github.com/appserver-io/description/pull/27 and https://github.com/appserver-io-psr/application-server/pull/1 .
