### PR TITLE
Validate session identifier before lookup in filesystem

### DIFF
--- a/src/AppserverIo/Appserver/ServletEngine/Http/Request.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Http/Request.php
@@ -944,8 +944,14 @@ class Request implements HttpServletRequestInterface, ContextInterface
             return;
         }
 
-        // find or create a new session (if flag has been set)
-        $session = $manager->find($id);
+        // initialize empty session variable
+        $session = null;
+
+        // verify that the session id has a valid format
+        if (preg_match('/^[A-z0-9]+$/', $id)) {
+            // attempt to retrieve existing session
+            $session = $manager->find($id);
+        }
 
         // if we can't find a session or session has been expired and we want to create a new one
         if ($session == null && $create === true) {


### PR DESCRIPTION
Prevents an attacker from including (and thereby temporarily locking) arbitrary files by using manipulated input within FilesystemSessionHandler::load().