### PR TITLE
Retrieve session manager via current request

### DIFF
--- a/src/AppserverIo/Appserver/ServletEngine/Http/SessionWrapper.php
+++ b/src/AppserverIo/Appserver/ServletEngine/Http/SessionWrapper.php
@@ -163,7 +163,7 @@ class SessionWrapper extends HttpSessionWrapper
         $this->setId(SessionUtils::generateRandomString());
 
         // load the session manager
-        $sessionManager = $this->getContext()->search(SessionManagerInterface::IDENTIFIER);
+        $sessionManager = $this->getRequest()->getSessionManager();
 
         // attach this session with the new ID
         $sessionManager->attach($this->getSession());


### PR DESCRIPTION
Uses the current request instance in order to retrieve the SessionManager.
This is necessary in order for `renewId()` to work.