### PR TITLE
WIP: Run as www-data inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,13 +58,6 @@ RUN ln -s /opt/appserver/bin/composer.phar /usr/local/bin/composer \
     # install composer dependencies
     && composer install --prefer-dist --no-dev --no-interaction --optimize-autoloader \
 
-    # modify user-rights in configuration
-    && sed -i "s/www-data/root/g" etc/appserver/appserver.xml \
-
-    # replace the default user/group for the PHP-FPM configuration
-    && sed -i "s/user = www-data/user = root/g" etc/php-fpm.conf \
-    && sed -i "s/group = www-data/group = root/g" etc/php-fpm.conf \
-
     # modify system logger configuration
     && sed -i "s/var\/log\/appserver-errors.log/php:\/\/stderr/g" etc/appserver/appserver.xml \
 
@@ -91,7 +84,10 @@ RUN ln -s /opt/appserver/bin/composer.phar /usr/local/bin/composer \
     && sed -i "s/;always_populate_raw_post_data = On/always_populate_raw_post_data = -1/g" etc/php-fpm-fcgi.ini \
 
     # create a symlink to the supervisord configuration file
-    && ln -s /opt/appserver/etc/supervisor/conf.d/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+    && ln -s /opt/appserver/etc/supervisor/conf.d/supervisord.conf /etc/supervisor/conf.d/supervisord.conf \
+
+    # change ownership to www-data:www-data
+    && chown -R www-data:www-data /opt/appserver
 
 ################################################################################
 


### PR DESCRIPTION
apserver.io and php-fpm are currently configured to run as root inside docker containers. This PR restores the default behaviour which is running as the user "www-data".